### PR TITLE
remove xdotool check

### DIFF
--- a/lua/stylish/components/menu.lua
+++ b/lua/stylish/components/menu.lua
@@ -8,7 +8,6 @@ local MouseHandler = require 'stylish.common.mouse_hover_handler'
 local Util = require 'stylish.common.util'
 
 --
-local XDOTOOL = Util.file_exists('/usr/bin/xdotool')
 
 local function get_raw_menu(tbl, stack)
   local stack_idx
@@ -79,7 +78,7 @@ function Menu:new(menu_data, opts, on_choice)
   this.default_prompt = opts.prompt
   this.title = opts.prompt
   this.kind = opts.kind or 'default'
-  this.experimental_mouse = (XDOTOOL and opts.experimental_mouse)
+  this.experimental_mouse = opts.experimental_mouse
 
   local screenrow = opts.position and opts.position.screenrow
   local screencol = opts.position and opts.position.screencol


### PR DESCRIPTION
there is no need to check that xdotool exists at that specific path '/usr/bin/xdotool', I could have installed a fork at '/usr/local/bin/xdotool'. Mine currently lives at /etc/profiles/per-user/teto/bin/xdotool. One check could be that it is in PATH. 
Even better would be to check errors from vim.fn.system or add a checkhealth file.

This current change allowed me to create a simple package for nix.